### PR TITLE
Fix panic when an uppercased mail is provided

### DIFF
--- a/cmd/arguments.go
+++ b/cmd/arguments.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 func parseMailAndOffsetArgs(args []string) (string, int) {
@@ -25,7 +26,11 @@ func parseMailAndOffsetArgs(args []string) (string, int) {
 		errorExit()
 	}
 
-	return args[0], offset
+	// Providing an uppercased email triggers a panic.
+	// In the web interface there is a redirection to
+	// the inbox with the address lowercased so we mimic
+	// this behaviour
+	return strings.ToLower(args[0]), offset
 }
 
 func checkOffset(count int, offset int) {

--- a/cmd/arguments_test.go
+++ b/cmd/arguments_test.go
@@ -42,6 +42,16 @@ func TestParseMailAndOffsetArgsWithSecondArgumentLessThan0(t *testing.T) {
 	parseMailAndOffsetArgs([]string{"test", "0"})
 }
 
+func TestParseMailAndOffsetArgsWithAnUpperCasedEmail(t *testing.T) {
+	perror = func(err error) {
+		assert.EqualError(t, err, `argument "test" must be an integer`, "Must return an error")
+	}
+
+	email, offset := parseMailAndOffsetArgs([]string{"TeSt", "1"})
+	assert.Equal(t, email, "test")
+	assert.Equal(t, offset, 1)
+}
+
 func TestCheckOffsetWithOffsetGreaterThanCount(t *testing.T) {
 	perror = func(err error) {
 		assert.EqualError(t, err, `Lower your offset value`, "Must return an error")

--- a/cmd/inbox_flush.go
+++ b/cmd/inbox_flush.go
@@ -19,7 +19,7 @@ var inboxFlushCmd = &cobra.Command{
 			errorExit()
 		}
 
-		in, err := inbox.ParseInboxPages(args[0], 1)
+		in, err := inbox.ParseInboxPages(parseMailAndOffsetArgs([]string{args[0], "1"}))
 		if err != nil {
 			perror(err)
 			errorExit()


### PR DESCRIPTION
When an uppercased email is provided, it triggers a panic. In the web interface there is a redirection to the inbox with the address lowercased so we mimic this behaviour.

Fix #65 